### PR TITLE
Avoid "Undefined index: column" in Criteria.php

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -1661,7 +1661,9 @@ class Criteria
             $sb .= "\nParams: ";
             $paramstr = [];
             foreach ($params as $param) {
-                $paramstr[] = $param['table'] . '.' . $param['column'] . ' => ' . var_export($param['value'], true);
+                $paramstr[] = isset($param['table']) ? $param['table'] . '.' : ''
+                    . $param['column'] ?? ''
+                    . isset($param['value']) ? ' => ' . var_export($param['value'], true) : '';
             }
             $sb .= implode(', ', $paramstr);
         } catch (Exception $exc) {

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -1661,9 +1661,9 @@ class Criteria
             $sb .= "\nParams: ";
             $paramstr = [];
             foreach ($params as $param) {
-                $paramstr[] = isset($param['table']) ? $param['table'] . '.' : ''
-                    . $param['column'] ?? ''
-                    . isset($param['value']) ? ' => ' . var_export($param['value'], true) : '';
+                $paramstr[] = (isset($param['table']) ? $param['table'] . '.' : '')
+                    . ($param['column'] ?? '')
+                    . (isset($param['value']) ? ' => ' . var_export($param['value'], true) : '');
             }
             $sb .= implode(', ', $paramstr);
         } catch (Exception $exc) {


### PR DESCRIPTION
I'm getting thousands of "PHP Notice:  Undefined index: column" in server logs.

There is no guarantee that createSelectSql($params) will add those keys in $params, so, protecting access to those keys.